### PR TITLE
Fix race conditions due to MVar usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Revision history for dap
 
+## Unreleased -- YYYY-mm-dd
+
+* `Adaptor` has an additional type parameter denoting the type of the request
+    we are responding to. Crucially, this will be `Request` when responding to a
+    DAP request (e.g. in `send***` functions).
+    On the other hand, this will be `()` for the `withAdaptor` continuation
+    argument of `registerNewDebugSession` which unlifts `Adaptor` to `IO`
+    because, when unlifting, we are not replying to any request.
+
 ## 0.1.0.0 -- YYYY-mm-dd
 
 * First version. Released on an unsuspecting world.

--- a/dap.cabal
+++ b/dap.cabal
@@ -27,17 +27,17 @@ library
     DAP.Types
     DAP.Utils
   build-depends:
-    aeson                >= 2.0.3  && < 2.1,
+    aeson                >= 2.0.3  && < 2.3,
     aeson-pretty         >= 0.8.9  && < 0.9,
     base                 < 5,
-    bytestring           >= 0.11.4 && < 0.12,
+    bytestring           >= 0.11.4 && < 0.13,
     containers           >= 0.6.5  && < 0.7,
     lifted-base          >= 0.2.3  && < 0.3,
     monad-control        >= 1.0.3  && < 1.1,
-    mtl                  >= 2.2.2  && < 2.3,
+    mtl                  >= 2.2.2  && < 2.4,
     network              >= 3.1.2  && < 3.2,
     network-simple       >= 0.4.5  && < 0.5,
-    text                 >= 1.2.5  && < 1.3,
+    text                 >= 1.2.5  && < 2.2,
     time                 >= 1.11.1 && < 1.12,
     unordered-containers >= 0.2.19 && < 0.3,
     stm                  >= 2.5.0  && < 2.6,

--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,6 @@
 { pkgs ? import <nixpkgs> {} }:
 let
-  dap = pkgs.haskell.packages.ghc927.callCabal2nix "dap" ./. {};
+  dap = pkgs.haskell.packages.ghc966.callCabal2nix "dap" ./. {};
 in
 {
   inherit dap pkgs;

--- a/src/DAP.hs
+++ b/src/DAP.hs
@@ -1,3 +1,4 @@
+----------------------------------------------------------------------------
 module DAP
   ( module DAP.Adaptor
   , module DAP.Event
@@ -6,10 +7,11 @@ module DAP
   , module DAP.Server
   , module DAP.Types
   ) where
-
+----------------------------------------------------------------------------
 import DAP.Adaptor
 import DAP.Event
 import DAP.Internal
 import DAP.Response
 import DAP.Server
 import DAP.Types
+----------------------------------------------------------------------------

--- a/src/DAP/Event.hs
+++ b/src/DAP/Event.hs
@@ -50,13 +50,13 @@ module DAP.Event
 import           DAP.Types
 import           DAP.Adaptor
 ----------------------------------------------------------------------------
-sendBreakpointEvent :: BreakpointEvent -> Adaptor app ()
+sendBreakpointEvent :: BreakpointEvent -> Adaptor app Request ()
 sendBreakpointEvent = sendSuccesfulEvent EventTypeBreakpoint . setBody
 ----------------------------------------------------------------------------
-sendCapabilitiesEvent :: CapabilitiesEvent -> Adaptor app ()
+sendCapabilitiesEvent :: CapabilitiesEvent -> Adaptor app Request ()
 sendCapabilitiesEvent = sendSuccesfulEvent EventTypeCapabilities . setBody
 ----------------------------------------------------------------------------
-sendContinuedEvent :: ContinuedEvent -> Adaptor app ()
+sendContinuedEvent :: ContinuedEvent -> Adaptor app Request ()
 sendContinuedEvent = sendSuccesfulEvent EventTypeContinued . setBody
 ----------------------------------------------------------------------------
 defaultContinuedEvent :: ContinuedEvent
@@ -66,7 +66,7 @@ defaultContinuedEvent
   , continuedEventAllThreadsContinued = False
   }
 ----------------------------------------------------------------------------
-sendExitedEvent :: ExitedEvent -> Adaptor app ()
+sendExitedEvent :: ExitedEvent -> Adaptor app Request ()
 sendExitedEvent = sendSuccesfulEvent EventTypeExited . setBody
 ----------------------------------------------------------------------------
 defaultExitedEvent :: ExitedEvent
@@ -75,10 +75,10 @@ defaultExitedEvent
   { exitedEventExitCode = 0
   }
 ----------------------------------------------------------------------------
-sendInitializedEvent :: Adaptor app ()
+sendInitializedEvent :: Adaptor app Request ()
 sendInitializedEvent = sendSuccesfulEvent EventTypeInitialized (pure ())
 ----------------------------------------------------------------------------
-sendInvalidatedEvent :: InvalidatedEvent -> Adaptor app ()
+sendInvalidatedEvent :: InvalidatedEvent -> Adaptor app Request ()
 sendInvalidatedEvent = sendSuccesfulEvent EventTypeInvalidated . setBody
 ----------------------------------------------------------------------------
 defaultInvalidatedEvent :: InvalidatedEvent
@@ -90,10 +90,10 @@ defaultInvalidatedEvent
   }
 
 ----------------------------------------------------------------------------
-sendLoadedSourceEvent :: LoadedSourceEvent -> Adaptor app ()
+sendLoadedSourceEvent :: LoadedSourceEvent -> Adaptor app Request ()
 sendLoadedSourceEvent = sendSuccesfulEvent EventTypeLoadedSource . setBody
 ----------------------------------------------------------------------------
-sendMemoryEvent :: MemoryEvent -> Adaptor app ()
+sendMemoryEvent :: MemoryEvent -> Adaptor app Request ()
 sendMemoryEvent = sendSuccesfulEvent EventTypeMemory . setBody
 ----------------------------------------------------------------------------
 defaultMemoryEvent :: MemoryEvent
@@ -104,10 +104,10 @@ defaultMemoryEvent
   , memoryEventCount            = 0
   }
 ----------------------------------------------------------------------------
-sendModuleEvent :: ModuleEvent -> Adaptor app ()
+sendModuleEvent :: ModuleEvent -> Adaptor app Request ()
 sendModuleEvent = sendSuccesfulEvent EventTypeModule . setBody
 ----------------------------------------------------------------------------
-sendOutputEvent :: OutputEvent -> Adaptor app ()
+sendOutputEvent :: OutputEvent -> Adaptor app r ()
 sendOutputEvent = sendSuccesfulEvent EventTypeOutput . setBody
 ----------------------------------------------------------------------------
 defaultOutputEvent :: OutputEvent
@@ -123,7 +123,7 @@ defaultOutputEvent
   , outputEventData               = Nothing
   }
 ----------------------------------------------------------------------------
-sendProcessEvent :: ProcessEvent -> Adaptor app ()
+sendProcessEvent :: ProcessEvent -> Adaptor app Request ()
 sendProcessEvent = sendSuccesfulEvent EventTypeProcess . setBody
 ----------------------------------------------------------------------------
 defaultProcessEvent :: ProcessEvent
@@ -136,7 +136,7 @@ defaultProcessEvent
   , processEventPointerSize     = Nothing
   }
 ----------------------------------------------------------------------------
-sendProgressEndEvent :: ProgressEndEvent -> Adaptor app ()
+sendProgressEndEvent :: ProgressEndEvent -> Adaptor app Request ()
 sendProgressEndEvent = sendSuccesfulEvent EventTypeProgressEnd . setBody
 ----------------------------------------------------------------------------
 defaultProgressEndEvent :: ProgressEndEvent
@@ -146,7 +146,7 @@ defaultProgressEndEvent
   , progressEndEventMessage     = Nothing
   }
 ----------------------------------------------------------------------------
-sendProgressStartEvent :: ProgressStartEvent -> Adaptor app ()
+sendProgressStartEvent :: ProgressStartEvent -> Adaptor app Request ()
 sendProgressStartEvent = sendSuccesfulEvent EventTypeProgressStart . setBody
 ----------------------------------------------------------------------------
 defaultProgressStartEvent :: ProgressStartEvent
@@ -160,7 +160,7 @@ defaultProgressStartEvent
   , progressStartEventPercentage  = Nothing
   }
 ----------------------------------------------------------------------------
-sendProgressUpdateEvent :: ProgressUpdateEvent -> Adaptor app ()
+sendProgressUpdateEvent :: ProgressUpdateEvent -> Adaptor app Request ()
 sendProgressUpdateEvent = sendSuccesfulEvent EventTypeProgressUpdate . setBody
 ----------------------------------------------------------------------------
 defaultProgressUpdateEvent :: ProgressUpdateEvent
@@ -171,7 +171,7 @@ defaultProgressUpdateEvent
   , progressUpdateEventPercentage = Nothing
   }
 ----------------------------------------------------------------------------
-sendStoppedEvent :: StoppedEvent -> Adaptor app ()
+sendStoppedEvent :: StoppedEvent -> Adaptor app Request ()
 sendStoppedEvent = sendSuccesfulEvent EventTypeStopped . setBody
 ----------------------------------------------------------------------------
 defaultStoppedEvent :: StoppedEvent
@@ -186,7 +186,7 @@ defaultStoppedEvent
   , stoppedEventHitBreakpointIds  = []
   }
 ----------------------------------------------------------------------------
-sendTerminatedEvent :: TerminatedEvent -> Adaptor app ()
+sendTerminatedEvent :: TerminatedEvent -> Adaptor app Request ()
 sendTerminatedEvent = sendSuccesfulEvent EventTypeTerminated . setBody
 ----------------------------------------------------------------------------
 defaultTerminatedEvent :: TerminatedEvent
@@ -195,7 +195,7 @@ defaultTerminatedEvent
   { terminatedEventRestart = False
   }
 ----------------------------------------------------------------------------
-sendThreadEvent :: ThreadEvent -> Adaptor app ()
+sendThreadEvent :: ThreadEvent -> Adaptor app Request ()
 sendThreadEvent = sendSuccesfulEvent EventTypeThread . setBody
 ----------------------------------------------------------------------------
 defaultThreadEvent :: ThreadEvent

--- a/src/DAP/Event.hs
+++ b/src/DAP/Event.hs
@@ -107,7 +107,7 @@ defaultMemoryEvent
 sendModuleEvent :: ModuleEvent -> Adaptor app Request ()
 sendModuleEvent = sendSuccesfulEvent EventTypeModule . setBody
 ----------------------------------------------------------------------------
-sendOutputEvent :: OutputEvent -> Adaptor app r ()
+sendOutputEvent :: OutputEvent -> Adaptor app request ()
 sendOutputEvent = sendSuccesfulEvent EventTypeOutput . setBody
 ----------------------------------------------------------------------------
 defaultOutputEvent :: OutputEvent

--- a/src/DAP/Response.hs
+++ b/src/DAP/Response.hs
@@ -64,13 +64,13 @@ import           DAP.Adaptor
 import           DAP.Types
 ----------------------------------------------------------------------------
 -- | AttachResponse has no body by default
-sendAttachResponse :: Adaptor app ()
+sendAttachResponse :: Adaptor app Request ()
 sendAttachResponse = sendSuccesfulEmptyResponse
 ----------------------------------------------------------------------------
 -- | BreakpointLocationResponse has no body by default
 sendBreakpointLocationsResponse
   :: [BreakpointLocation]
-  -> Adaptor app ()
+  -> Adaptor app Request ()
 sendBreakpointLocationsResponse
   = sendSuccesfulResponse
   . setBody
@@ -79,7 +79,7 @@ sendBreakpointLocationsResponse
 -- | 'SetDataBreakpointsResponse'
 sendSetDataBreakpointsResponse
   :: [Breakpoint]
-  -> Adaptor app ()
+  -> Adaptor app Request ()
 sendSetDataBreakpointsResponse
   = sendSuccesfulResponse
   . setBody
@@ -88,7 +88,7 @@ sendSetDataBreakpointsResponse
 -- | BreakpointResponse has no body by default
 sendSetBreakpointsResponse
   :: [Breakpoint]
-  -> Adaptor app ()
+  -> Adaptor app Request ()
 sendSetBreakpointsResponse
   = sendSuccesfulResponse
   . setBody
@@ -97,7 +97,7 @@ sendSetBreakpointsResponse
 -- | SetInstructionsBreakpointResponse has no body by default
 sendSetInstructionBreakpointsResponse
   :: [Breakpoint]
-  -> Adaptor app ()
+  -> Adaptor app Request ()
 sendSetInstructionBreakpointsResponse
   = sendSuccesfulResponse
   . setBody
@@ -106,7 +106,7 @@ sendSetInstructionBreakpointsResponse
 -- | SetFunctionBreakpointResponse has no body by default
 sendSetFunctionBreakpointsResponse
   :: [Breakpoint]
-  -> Adaptor app ()
+  -> Adaptor app Request ()
 sendSetFunctionBreakpointsResponse
   = sendSuccesfulResponse
   . setBody
@@ -115,7 +115,7 @@ sendSetFunctionBreakpointsResponse
 -- | SetExceptionBreakpointsResponse has no body by default
 sendSetExceptionBreakpointsResponse
   :: [Breakpoint]
-  -> Adaptor app ()
+  -> Adaptor app Request ()
 sendSetExceptionBreakpointsResponse
   = sendSuccesfulResponse
   . setBody
@@ -124,147 +124,147 @@ sendSetExceptionBreakpointsResponse
 -- | ContinueResponse
 sendContinueResponse
   :: ContinueResponse
-  -> Adaptor app ()
+  -> Adaptor app Request ()
 sendContinueResponse continueResponse = do
   sendSuccesfulResponse (setBody continueResponse)
 ----------------------------------------------------------------------------
 -- | ConfigurationDoneResponse
 sendConfigurationDoneResponse
-  :: Adaptor app ()
+  :: Adaptor app Request ()
 sendConfigurationDoneResponse = do
   sendSuccesfulEmptyResponse
 ----------------------------------------------------------------------------
 -- | LaunchResponse
 sendLaunchResponse
-  :: Adaptor app ()
+  :: Adaptor app Request ()
 sendLaunchResponse = sendSuccesfulEmptyResponse
 ----------------------------------------------------------------------------
 -- | RestartResponse
 sendRestartResponse
-  :: Adaptor app ()
+  :: Adaptor app Request ()
 sendRestartResponse = sendSuccesfulEmptyResponse
 ----------------------------------------------------------------------------
 -- | DisconnectResponse
 sendDisconnectResponse
-  :: Adaptor app ()
+  :: Adaptor app Request ()
 sendDisconnectResponse = sendSuccesfulEmptyResponse
 ----------------------------------------------------------------------------
 -- | TerminateResponse
 sendTerminateResponse
-  :: Adaptor app ()
+  :: Adaptor app Request ()
 sendTerminateResponse = sendSuccesfulEmptyResponse
 ----------------------------------------------------------------------------
 -- | NextResponse
 sendNextResponse
-  :: Adaptor app ()
+  :: Adaptor app Request ()
 sendNextResponse = sendSuccesfulEmptyResponse
 ----------------------------------------------------------------------------
 -- | StepInResponse
 sendStepInResponse
-  :: Adaptor app ()
+  :: Adaptor app Request ()
 sendStepInResponse = sendSuccesfulEmptyResponse
 ----------------------------------------------------------------------------
 -- | StepOutResponse
 sendStepOutResponse
-  :: Adaptor app ()
+  :: Adaptor app Request ()
 sendStepOutResponse = sendSuccesfulEmptyResponse
 ----------------------------------------------------------------------------
 -- | StepBackResponse
 sendStepBackResponse
-  :: Adaptor app ()
+  :: Adaptor app Request ()
 sendStepBackResponse = sendSuccesfulEmptyResponse
 ----------------------------------------------------------------------------
 -- | ReverseContinueResponse
 sendReverseContinueResponse
-  :: Adaptor app ()
+  :: Adaptor app Request ()
 sendReverseContinueResponse = sendSuccesfulEmptyResponse
 ----------------------------------------------------------------------------
 -- | RestartFrameResponse
 sendRestartFrameResponse
-  :: Adaptor app ()
+  :: Adaptor app Request ()
 sendRestartFrameResponse = sendSuccesfulEmptyResponse
 ----------------------------------------------------------------------------
 -- | InitializeReponse
 sendInitializeResponse
-  :: Adaptor app ()
+  :: Adaptor app Request ()
 sendInitializeResponse = do
   capabilities <- getServerCapabilities
   sendSuccesfulResponse (setBody capabilities)
 ----------------------------------------------------------------------------
 -- | GotoResponse
 sendGotoResponse
-  :: Adaptor app ()
+  :: Adaptor app Request ()
 sendGotoResponse = sendSuccesfulEmptyResponse
 ----------------------------------------------------------------------------
 -- | GotoTargetsResponse
 sendGotoTargetsResponse
-  :: Adaptor app ()
+  :: Adaptor app Request ()
 sendGotoTargetsResponse = sendSuccesfulEmptyResponse
 ----------------------------------------------------------------------------
 -- | PauseResponse
 sendPauseResponse
-  :: Adaptor app ()
+  :: Adaptor app Request ()
 sendPauseResponse = sendSuccesfulEmptyResponse
 ----------------------------------------------------------------------------
 -- | TerminateThreadsResponse
 sendTerminateThreadsResponse
-  :: Adaptor app ()
+  :: Adaptor app Request ()
 sendTerminateThreadsResponse = sendSuccesfulEmptyResponse
 ----------------------------------------------------------------------------
-sendModulesResponse :: ModulesResponse -> Adaptor app ()
+sendModulesResponse :: ModulesResponse -> Adaptor app Request ()
 sendModulesResponse = sendSuccesfulResponse . setBody
 ----------------------------------------------------------------------------
-sendStackTraceResponse :: StackTraceResponse -> Adaptor app ()
+sendStackTraceResponse :: StackTraceResponse -> Adaptor app Request ()
 sendStackTraceResponse = sendSuccesfulResponse . setBody
 ----------------------------------------------------------------------------
-sendSourceResponse :: SourceResponse -> Adaptor app ()
+sendSourceResponse :: SourceResponse -> Adaptor app Request ()
 sendSourceResponse = sendSuccesfulResponse . setBody
 ----------------------------------------------------------------------------
-sendThreadsResponse :: [Thread] -> Adaptor app ()
+sendThreadsResponse :: [Thread] -> Adaptor app Request ()
 sendThreadsResponse = sendSuccesfulResponse . setBody . ThreadsResponse
 ----------------------------------------------------------------------------
-sendLoadedSourcesResponse :: [Source] -> Adaptor app ()
+sendLoadedSourcesResponse :: [Source] -> Adaptor app Request ()
 sendLoadedSourcesResponse = sendSuccesfulResponse . setBody . LoadedSourcesResponse
 ----------------------------------------------------------------------------
-sendWriteMemoryResponse :: WriteMemoryResponse -> Adaptor app ()
+sendWriteMemoryResponse :: WriteMemoryResponse -> Adaptor app Request ()
 sendWriteMemoryResponse = sendSuccesfulResponse . setBody
 ----------------------------------------------------------------------------
-sendReadMemoryResponse :: ReadMemoryResponse -> Adaptor app ()
+sendReadMemoryResponse :: ReadMemoryResponse -> Adaptor app Request ()
 sendReadMemoryResponse = sendSuccesfulResponse . setBody
 ----------------------------------------------------------------------------
-sendCompletionsResponse :: CompletionsResponse -> Adaptor app ()
+sendCompletionsResponse :: CompletionsResponse -> Adaptor app Request ()
 sendCompletionsResponse = sendSuccesfulResponse . setBody
 ----------------------------------------------------------------------------
-sendDataBreakpointInfoResponse :: DataBreakpointInfoResponse -> Adaptor app ()
+sendDataBreakpointInfoResponse :: DataBreakpointInfoResponse -> Adaptor app Request ()
 sendDataBreakpointInfoResponse = sendSuccesfulResponse . setBody
 ----------------------------------------------------------------------------
-sendDisassembleResponse :: DisassembleResponse -> Adaptor app ()
+sendDisassembleResponse :: DisassembleResponse -> Adaptor app Request ()
 sendDisassembleResponse = sendSuccesfulResponse . setBody
 ----------------------------------------------------------------------------
-sendEvaluateResponse :: EvaluateResponse -> Adaptor app ()
+sendEvaluateResponse :: EvaluateResponse -> Adaptor app Request ()
 sendEvaluateResponse = sendSuccesfulResponse . setBody
 ----------------------------------------------------------------------------
-sendExceptionInfoResponse :: ExceptionInfoResponse -> Adaptor app ()
+sendExceptionInfoResponse :: ExceptionInfoResponse -> Adaptor app Request ()
 sendExceptionInfoResponse = sendSuccesfulResponse . setBody
 ----------------------------------------------------------------------------
-sendScopesResponse :: ScopesResponse -> Adaptor app ()
+sendScopesResponse :: ScopesResponse -> Adaptor app Request ()
 sendScopesResponse = sendSuccesfulResponse . setBody
 ----------------------------------------------------------------------------
-sendSetExpressionResponse :: SetExpressionResponse -> Adaptor app ()
+sendSetExpressionResponse :: SetExpressionResponse -> Adaptor app Request ()
 sendSetExpressionResponse = sendSuccesfulResponse . setBody
 ----------------------------------------------------------------------------
-sendSetVariableResponse :: SetVariableResponse -> Adaptor app ()
+sendSetVariableResponse :: SetVariableResponse -> Adaptor app Request ()
 sendSetVariableResponse = sendSuccesfulResponse . setBody
 ----------------------------------------------------------------------------
-sendStepInTargetsResponse :: StepInTargetsResponse -> Adaptor app ()
+sendStepInTargetsResponse :: StepInTargetsResponse -> Adaptor app Request ()
 sendStepInTargetsResponse = sendSuccesfulResponse . setBody
 ----------------------------------------------------------------------------
-sendVariablesResponse :: VariablesResponse -> Adaptor app ()
+sendVariablesResponse :: VariablesResponse -> Adaptor app Request ()
 sendVariablesResponse = sendSuccesfulResponse . setBody
 ----------------------------------------------------------------------------
-sendRunInTerminalResponse :: RunInTerminalResponse -> Adaptor app ()
+sendRunInTerminalResponse :: RunInTerminalResponse -> Adaptor app Request ()
 sendRunInTerminalResponse = sendSuccesfulResponse . setBody
 ----------------------------------------------------------------------------
-sendStartDebuggingResponse :: Adaptor app ()
+sendStartDebuggingResponse :: Adaptor app Request ()
 sendStartDebuggingResponse = sendSuccesfulEmptyResponse
 ----------------------------------------------------------------------------

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -106,7 +106,7 @@ main = withServer $
 --
 mockServerTalk
   :: Command
-  -> Adaptor app ()
+  -> Adaptor app Request ()
 mockServerTalk CommandInitialize = do
   sendInitializeResponse
   sendInitializedEvent


### PR DESCRIPTION
Consider the deadlock described in #6

We fix this by getting rid of the `MVar` internally and adding a `ReaderT` to the stack transformer with a debugger-server-wide sessionId backed by an IORef.

`Adaptor` now has an additional type parameter denoting the type of the request we are responding to. Crucially, this will be `Request` when responding to a DAP request (e.g. in `send***` functions). On the other hand, this will be `()` for the `withAdaptor` continuation argument of `registerNewDebugSession` which unlifts `Adaptor` to `IO` because, when unlifting, we are not replying to any request.

These changes to the internal implementation of `Adaptor` which allow us to get rid of the `MVar` are sufficient to fix the deadlock and now avoid footguns uses of `withAdaptor`.

Fixes #6