### PR TITLE
Allow a client to explicitly terminate the server

### DIFF
--- a/dap.cabal
+++ b/dap.cabal
@@ -26,6 +26,7 @@ library
     DAP.Server
     DAP.Types
     DAP.Utils
+    DAP.Log
   build-depends:
     aeson                >= 2.0.3  && < 2.3,
     aeson-pretty         >= 0.8.9  && < 0.9,
@@ -41,7 +42,8 @@ library
     time                 >= 1.11.1 && < 1.12,
     unordered-containers >= 0.2.19 && < 0.3,
     stm                  >= 2.5.0  && < 2.6,
-    transformers-base    >= 0.4.6  && < 0.5
+    transformers-base    >= 0.4.6  && < 0.5,
+    co-log-core          >= 0.3    && < 0.4
   ghc-options:
     -Wall
   hs-source-dirs:
@@ -66,6 +68,7 @@ test-suite tests
     DAP.Types
     DAP.Event
     DAP.Utils
+    DAP.Log
   build-depends:
       aeson
     , aeson-pretty
@@ -85,6 +88,7 @@ test-suite tests
     , time
     , transformers-base
     , unordered-containers
+    , co-log-core
   default-language:
     Haskell2010
 

--- a/src/DAP/Internal.hs
+++ b/src/DAP/Internal.hs
@@ -9,16 +9,9 @@
 ----------------------------------------------------------------------------
 module DAP.Internal
   ( withLock
-  , withGlobalLock
   ) where
 ----------------------------------------------------------------------------
-import           Control.Concurrent         ( modifyMVar_, newMVar, MVar )
-import           System.IO.Unsafe           ( unsafePerformIO )
-----------------------------------------------------------------------------
--- | Used for logging in the presence of multiple threads.
-lock :: MVar ()
-{-# NOINLINE lock #-}
-lock = unsafePerformIO $ newMVar ()
+import           Control.Concurrent
 ----------------------------------------------------------------------------
 -- | Used for performing actions (e.g. printing debug logs to stdout)
 -- Also used for writing to each connections Handle.
@@ -28,12 +21,4 @@ lock = unsafePerformIO $ newMVar ()
 --
 withLock :: MVar () -> IO () -> IO ()
 withLock mvar action = modifyMVar_ mvar $ \x -> x <$ action
-----------------------------------------------------------------------------
--- | Used for performing actions (e.g. printing debug logs to stdout)
--- Ensures operations occur one thread at a time.
---
--- Used internally only
---
-withGlobalLock :: IO () -> IO ()
-withGlobalLock = withLock lock
 ----------------------------------------------------------------------------

--- a/src/DAP/Log.hs
+++ b/src/DAP/Log.hs
@@ -1,0 +1,46 @@
+module DAP.Log (
+    DebugStatus (..)
+  , DAPLog(..)
+  , LogAction(..)
+  , Level(..)
+  , (<&)
+  , cmap
+  , cfilter
+  , mkDebugMessage
+  , renderDAPLog
+) where
+
+import Data.Text (Text)
+import           Network.Socket                  ( SockAddr )
+import Colog.Core
+import qualified Data.Text as T
+import DAP.Utils
+
+----------------------------------------------------------------------------
+data Level = DEBUG | INFO | WARN | ERROR
+  deriving (Show, Eq)
+----------------------------------------------------------------------------
+data DebugStatus = SENT | RECEIVED
+  deriving (Show, Eq)
+
+data DAPLog =
+  DAPLog {
+      severity :: Level
+    , mDebugStatus :: Maybe DebugStatus
+    , addr     :: SockAddr
+    , message  :: Text
+    }
+  | GenericMessage { severity :: Level, message :: Text }
+
+mkDebugMessage :: Text -> DAPLog
+mkDebugMessage  = GenericMessage DEBUG
+
+renderDAPLog :: DAPLog -> Text
+renderDAPLog (GenericMessage _ t) = t
+renderDAPLog (DAPLog level maybeDebug log_addr msg) = T.concat
+      [ withBraces $ T.pack (show log_addr)
+      , withBraces $ T.pack (show level)
+      , maybe mempty (withBraces . T.pack . show) maybeDebug
+      , msg
+      ]
+

--- a/src/DAP/Utils.hs
+++ b/src/DAP/Utils.hs
@@ -32,6 +32,7 @@ import           Data.Proxy                 (Proxy(Proxy))
 import           Data.Typeable              ( Typeable, typeRep )
 import qualified Data.ByteString.Lazy.Char8 as BL8
 import qualified Data.ByteString.Char8      as BS
+import qualified Data.Text as T
 ----------------------------------------------------------------------------
 -- | Encodes DAP protocol message appropriately
 -- >
@@ -110,6 +111,6 @@ genericParseJSONWithModifier
   }
 ----------------------------------------------------------------------------
 -- | Log formatting util
-withBraces :: BL8.ByteString -> BL8.ByteString
+withBraces :: T.Text -> T.Text
 withBraces x  = "[" <> x <> "]"
 ----------------------------------------------------------------------------


### PR DESCRIPTION
Introduces exception `TerminateServer` which, if thrown by a debugger session, is re-thrown to the main thread to terminate the server.

This is useful if you are using the server in one-shot mode (only one execution per server)

This is based on #10 