### PR TITLE
Kill the printing of "Handling" to stderr

### DIFF
--- a/src/DAP/Server.hs
+++ b/src/DAP/Server.hs
@@ -46,7 +46,7 @@ import           Network.Simple.TCP         ( serve, HostPreference(Host) )
 import           Network.Socket             ( socketToHandle, withSocketsDo, SockAddr )
 import           System.IO                  ( hClose, hSetNewlineMode, Handle, Newline(CRLF)
                                             , NewlineMode(NewlineMode, outputNL, inputNL)
-                                            , IOMode(ReadWriteMode), stderr, hPrint)
+                                            , IOMode(ReadWriteMode) )
 import           System.IO.Error            ( isEOFError )
 import           System.Exit                ( exitWith, ExitCode(ExitSuccess) )
 import           Text.Read                  ( readMaybe )
@@ -176,7 +176,6 @@ exceptionHandler logAction handle address shouldLog serverThread (e :: SomeExcep
           = logger logAction ERROR address Nothing
             $ withBraces
             $ T.pack ("Unknown Exception: " <> show e)
-  hPrint stderr ("Handling" <> show e)
   when shouldLog $ do
     dumpError
     logger logAction INFO address (Just SENT) (withBraces "Closing Connection")


### PR DESCRIPTION
```
    The `"Handling " <> show e` message would get printed to the stderr of
    the dap server. This resulted in thinking something was wrong in
    inumerous occasions, seeing messages such as:

    [stderr] DAP.Se
    [stderr] rver/Handling:

    [stderr] ghc-internal:GHC.Internal.IO.Exception
    [stderr] .IOException:

    <socket: 13>: Da
    [stderr] ta.ByteString.hGetLine: end of file

    IPE backtrac
    [stderr] e:

    [stderr]   DAP.Server
    [stderr] .getHeaderHandle (src/DAP/Server.hs:(217,1)-(220,32))
    HasCallStack backtrace:
      ioException, called at
    [stderr]  libraries/ghc-internal/src/GHC/Internal/IO/H
    [stderr] andle/Internals.hs:353:11 in ghc-
    [stderr] internal:GHC.Internal.IO.Handle.Interna
    [stderr] ls

    (I had slightly tweaked the message to investigate what was going wrong)

    When, in reality, nothing was wrong. This was an EOF exception
    indicating the client had closed the connection.

    However, when looking at the logs, the "Handling" was misleading (and
    not easily correlated with the "Client has ended its connection below".

    All in all, I don't think we should print the "Handling" at all. If an
    exception is handled, it is handled. If it is not, then it gets logged
    to the appropriate logger as "Unknown Exception".
```