### PR TITLE
fix: Reverse request without payload trash

### DIFF
--- a/src/DAP/Adaptor.hs
+++ b/src/DAP/Adaptor.hs
@@ -306,7 +306,7 @@ sendReverseRequest
   :: ReverseCommand
   -> Adaptor app Request ()
 sendReverseRequest rcmd = send $ do
-  setField "type" MessageTypeRequest
+  setType MessageTypeRequest
   setField "command" rcmd
 ----------------------------------------------------------------------------
 -- | Send runInTerminal reverse request


### PR DESCRIPTION
`setField "type"` was just appending the "type" to the current payload.
We should use `setType` instead, which "starts from scratch" the
payload. It is also what we use for e.g. `sendSuccesfulResponse`,
`sendSuccesfulEvent`, `sendErrorResponse`, etc...

Fixes #34
